### PR TITLE
修复无法登录、位置签到失败的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,22 @@ PHP 版超星学习用自动签到，支持多用户签到，二次开发便捷�
 
 - 签到功能：
 
-支持普通签到，手势签到，~~二维码签到~~，位置签到，~~拍照签到~~
+支持普通签到，手势签到，~~二维码签到~~，位置签到，拍照签到（无图片上传）
 
 # 🎨 更新日志
 <details open>
+  <summary>2022/08/29</summary>
+  
+- 修复无法登录的Bug
+- 修复无法位置签到的Bug
+- 调整了curl的实现方法，方便后期debug
+</details open>
+<details>
   <summary>2022/06/06</summary>
   
 - 增加预签到
 - 修复无法签到的Bug
-</details open>
+</details>
 <details>
   <summary>2022/04/27</summary>
   

--- a/lib/Functions.php
+++ b/lib/Functions.php
@@ -10,6 +10,7 @@ define("TASK_ID_OLD", "http://mobilelearn.chaoxing.com/widget/pcpick/stu/index?c
 
 define("PRE_SIGN_API", "https://mobilelearn.chaoxing.com/newsign/preSign?courseId=%s&classId=%s&activePrimaryId=%s&general=1&sys=1&ls=1&appType=15&&tid=&ut=s");//预签到API
 define("SIGN_API", "https://mobilelearn.chaoxing.com/pptSign/stuSignajax?activeId=%s");//获取任务 ID
+define("SIGN_API_WITH_GPS", "https://mobilelearn.chaoxing.com/pptSign/stuSignajax?activeId=%s&latitude_gd=%s&longitude_gd=%s&longitude=%s&latitude=%s&address=%s"); //签到(位置)
 define("SIGN_API_OLD", "http://mobilelearn.chaoxing.com/widget/sign/pcStuSignController/preSign?activeId=%s&classId=%s&courseId=%s");//<旧方法>获取任务 ID
 
 /**
@@ -146,27 +147,38 @@ function post($parameter, $default = null, $filter = 'trim')
 /**
  *curl get请求
  */
-function curl_get($url, $cookie_jar = '')
+function curl_get($url, $cookie_jar = '', $header_type="PC")
 {
     $curl = curl_init();
     curl_setopt($curl, CURLOPT_URL, $url);//登陆后要从哪个页面获取信息
-    curl_setopt($curl, CURLOPT_HEADER, false);
+    curl_setopt($curl, CURLOPT_HEADER, true);
     curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
 
     //取消 SSL 证书验证
     curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, FALSE);
     curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, FALSE);
 
-    curl_setopt($curl, CURLOPT_USERAGENT, "Mozilla/5.0 (iPhone; CPU iPhone OS 15_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 (device:iPhone13,2) Language/zh-Hans com.ssreader.ChaoXingStudy/ChaoXingStudy_3_5.2.1_ios_phone_202204211530_81 (@Kalimdor)_14895834084271104281");
+    if($header_type == "PC"){
+        curl_setopt($curl, CURLOPT_USERAGENT, "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36");
+    }else{
+        curl_setopt($curl, CURLOPT_USERAGENT, "Mozilla/5.0 (iPhone; CPU iPhone OS 15_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 (device:iPhone13,2) Language/zh-Hans com.ssreader.ChaoXingStudy/ChaoXingStudy_3_5.2.1_ios_phone_202204211530_81 (@Kalimdor)_14895834084271104281");
+    }
+
     curl_setopt($curl, CURLOPT_TIMEOUT, 10);
 
+    // $streamVerboseHandle = fopen("out.txt", 'a+');
+	// curl_setopt($curl, CURLOPT_VERBOSE, 1);
+	// curl_setopt($curl, CURLOPT_STDERR, $streamVerboseHandle);
+  
     if (!empty($cookie_jar)) {
-        curl_setopt($curl, CURLOPT_COOKIEJAR, $cookie_jar); //保存返回的Cookie
-        curl_setopt($curl, CURLOPT_COOKIEFILE, $cookie_jar); //读取现有Cookie
+        curl_setopt($curl, CURLOPT_COOKIEFILE, realpath($cookie_jar)); //读取现有Cookie
+        curl_setopt($curl, CURLOPT_COOKIEJAR, realpath($cookie_jar)); //保存返回的Cookie
     }
 
     $content = curl_exec($curl);
-    curl_close($curl);
+    list($header, $body) = explode("\r\n\r\n", $content, 2);
 
-    return $content;
+    curl_close($curl);
+	// fclose($streamVerboseHandle);
+    return $body;
 }


### PR DESCRIPTION
无法登录的原因
---
若直接使用学习通的User-Agent，会触发”新设备登录“的2FA（见登录后响应包的json字段”toCheckMessage“）导致返回Cookies出错
但采用电脑的UA则可绕过2FA，并正常获取用户的Cookies。在此基础上，用电脑的UA获取的Cookies也可以实现在手机端登录的功能

其它修复：
---
1. 修复了位置签到（直接从签到页面匹配了签到经纬度，达到了签在老师脸上的效果（（（（（
2. cURL的部分现在也能返回请求头了，方便以后调试
